### PR TITLE
a2c dtype bugfix

### DIFF
--- a/policies/a2c.py
+++ b/policies/a2c.py
@@ -52,7 +52,7 @@ class Policy(DQN_POLICY):
         return string_actions
 
     def sample_action(self):
-        torch_state = torch.from_numpy(self.current_state).type(self.dtype_int)
+        torch_state = torch.from_numpy(self.current_state).type(self.dtype)
 
         probs, _, _ = self.target_model((Variable(torch_state)))
 


### PR DESCRIPTION
`dtype_int` in a2c's `sample_action` should be of type `FloatTensor` instead of `LongTensor`
else a2c throws the following error:

```
(C:\Anaconda3) C:\Github_Repos\tessler_Malmo>python main.py a2c single_room --number_of_agents 2 --malmo_ports 10000 10001 --retain_rgb --save_name a2c-test
2018-02-09 10:49:34 INFO: To view results, run 'python -m visdom.server'
2018-02-09 10:49:34 INFO: then head over to http://localhost:8097
2018-02-09 10:49:46 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
2018-02-09 10:49:47 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
2018-02-09 10:49:48 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
2018-02-09 10:49:48 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
2018-02-09 10:49:49 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
2018-02-09 10:49:50 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
2018-02-09 10:49:50 CRITICAL: Agent[0]: _load_mission_from_xml, Error starting mission
Traceback (most recent call last):
  File "main.py", line 79, in <module>
    True)
  File "C:\Github_Repos\tessler_Malmo\utilities\helpers.py", line 52, in play_full_episode
    action = policy.get_action(states, is_train)
  File "C:\Github_Repos\tessler_Malmo\policies\a2c.py", line 44, in get_action
    actions = self.sample_action()
  File "C:\Github_Repos\tessler_Malmo\policies\a2c.py", line 57, in sample_action
    probs, _, _ = self.target_model((Variable(torch_state)))
  File "C:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 325, in __call__
    result = self.forward(*input, **kwargs)
  File "C:\Github_Repos\tessler_Malmo\policies\models\actor_critic.py", line 37, in forward
    x = self.feature_extractor(inputs)
  File "C:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 325, in __call__
    result = self.forward(*input, **kwargs)
  File "C:\Anaconda3\lib\site-packages\torch\nn\modules\container.py", line 67, in forward
    input = module(input)
  File "C:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 325, in __call__
    result = self.forward(*input, **kwargs)
  File "C:\Anaconda3\lib\site-packages\torch\nn\modules\conv.py", line 277, in forward
    self.padding, self.dilation, self.groups)
  File "C:\Anaconda3\lib\site-packages\torch\nn\functional.py", line 90, in conv2d
    return f(input, weight, bias)
RuntimeError: Input type (CUDALongTensor) and weight type (CUDAFloatTensor) should be the same
```